### PR TITLE
Cleanup Dockerfile, add support for paho mqtt client_id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,9 @@
-FROM python:3.13-slim
-WORKDIR /app
-COPY requirements.txt ./
+FROM python:3-alpine
+WORKDIR /opt/mqtt4dsmr
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
-# The tmpfs mount is a workaround
-# https://github.com/rust-lang/cargo/issues/8719
-RUN --mount=type=tmpfs,target=/root/.cargo \
-    apt-get update \
- && apt-get install --yes --no-install-recommends \
-        build-essential libssl-dev libffi-dev cargo pkg-config \
- && pip install --root-user-action ignore --no-cache-dir -r requirements.txt \
- && apt-get autoremove --purge --yes \
-        build-essential libssl-dev libffi-dev cargo pkg-config \
- && apt-get clean \
- && rm -rf /root/.cache
-
-COPY . .
+COPY *.py .
 ARG VERSION_TAG=unknown
 ENV MQTT4DSMR_VERSION=$VERSION_TAG
 CMD [ "env", "SERIAL_DEVICE=/dev/ttyDSMR", "./mqtt4dsmr.py" ]

--- a/config.py
+++ b/config.py
@@ -73,7 +73,7 @@ class Config:
 
         self.MQTT_HOST = get_env_opt('MQTT_HOST', str, True)
         self.MQTT_PORT = get_env_opt('MQTT_PORT', int, False, None)
-        self.MQTT_CLIENT_ID = get_env_opt('MQTT_CLIENT_ID', str, None)
+        self.MQTT_CLIENT_ID = get_env_opt('MQTT_CLIENT_ID', str, False, "mqtt4dsmr")
         self.MQTT_TLS = get_env_opt('MQTT_TLS', bool, False, None)
         self.MQTT_TLS_INSECURE = get_env_opt('MQTT_TLS_INSECURE', bool, False, False)
         self.MQTT_CA_CERTS = get_env_opt('MQTT_CA_CERTS', str, False)

--- a/config.py
+++ b/config.py
@@ -73,6 +73,7 @@ class Config:
 
         self.MQTT_HOST = get_env_opt('MQTT_HOST', str, True)
         self.MQTT_PORT = get_env_opt('MQTT_PORT', int, False, None)
+        self.MQTT_CLIENT_ID = get_env_opt('MQTT_CLIENT_ID', str, None)
         self.MQTT_TLS = get_env_opt('MQTT_TLS', bool, False, None)
         self.MQTT_TLS_INSECURE = get_env_opt('MQTT_TLS_INSECURE', bool, False, False)
         self.MQTT_CA_CERTS = get_env_opt('MQTT_CA_CERTS', str, False)

--- a/mqtt4dsmr.py
+++ b/mqtt4dsmr.py
@@ -43,7 +43,7 @@ def main():
 
     cfg = Config()
 
-    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2,client_id=cfg.MQTT_CLIENT_ID)
 
     if cfg.MQTT_TLS:
         logging.info('Using MQTT over TLS')


### PR DESCRIPTION
Hi Antonie,

I've made some changes, primarily to hopefully (it seems, but time will tell) better handle disconnects/reconnects. The entities became unavailable after automated updates of mosquitto. I've only noticed that with mqtt4dsmr. With kamstrup-402-mqtt and zigbee2mqtt this didn't seem to happen, or it got handled better. 

It seems that setting the client_id to a specified value this problem doesn't occur anymore. 

Other  than that, I've further reduced the size of the docker image from 173.1 MB to 81.2 MB. Didn't notice any problems and as far as I can tell (probably/maybe missing something), the image runs fine without cargo, so only the pip install command seems enough. 

Greetings, Arnoud